### PR TITLE
fix trailing space issue

### DIFF
--- a/bash_completion.py
+++ b/bash_completion.py
@@ -239,7 +239,18 @@ COMP_COUNT={end}
 COMP_CWORD={n}
 $_func {cmd} {prefix} {prev}
 
-for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo "${{COMPREPLY[i]}}"; done
+# print out completions, right-stripped if they contain no internal spaces
+shopt -s extglob
+for ((i=0;i<${{#COMPREPLY[*]}};i++))
+do
+    no_spaces="${{COMPREPLY[i]//[[:space:]]}}"
+    no_trailing_spaces="${{COMPREPLY[i]%%+([[:space:]])}}"
+    if [[ "$no_spaces" == "$no_trailing_spaces" ]]; then
+        echo "$no_trailing_spaces"
+    else
+        echo "${{COMPREPLY[i]}}"
+    fi
+done
 """
 
 


### PR DESCRIPTION
I noticed that commands like `git c` would complete to `git 'checkout '` because git adds an extra space to the end of the completion, which was being captured in the completion.  This PR fixes the git issue while retaining all whitespace when there is other internal whitespace.