### PR TITLE
Don't allow negative prefix lengths

### DIFF
--- a/bash_completion.py
+++ b/bash_completion.py
@@ -355,7 +355,7 @@ def bash_completions(prefix, line, begidx, endidx, env=None, paths=None,
     if '-o nospace' in complete_stmt:
         out = set([x.rstrip() for x in out])
 
-    return out, len(prefix) - strip_len
+    return out, max(len(prefix) - strip_len, 0)
 
 
 def bash_complete_line(line, return_line=True, **kwargs):

--- a/news/fix_negative_len.rst
+++ b/news/fix_negative_len.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* `bash_completion` will not return negative prefix lengths for files that need
+  to be string-escaped (files/folders with spaces in name)
+
+**Security:** None


### PR DESCRIPTION
For completions that can hit quote-escaped files with spaces in the name the
logic for decrementing the prefix length gets fouled up if the prefix is
blank (e.g. if you `cat <TAB>`)

```
>>> bash_completions('', 'cat ', 4, 4, dict())
({"'a file with spaces'", "'afile'"}, -1)
```

The minimum prefix length should be `0`.