### PR TITLE
fix completion which uses a subshell environment

### DIFF
--- a/bash_completion.py
+++ b/bash_completion.py
@@ -221,6 +221,18 @@ function _get_complete_statement {{
     complete -p {cmd} 2> /dev/null || echo "-F _minimal"
 }}
 
+function getarg {{
+    find=$1
+    shift 1
+    prev=""
+    for i in $* ; do
+        if [ "$prev" = "$find" ] ; then
+            echo $i
+        fi
+        prev=$i
+    done
+}}
+
 _complete_stmt=$(_get_complete_statement)
 if echo "$_complete_stmt" | grep --quiet -e "_minimal"
 then
@@ -228,15 +240,19 @@ then
     _complete_stmt=$(_get_complete_statement)
 fi
 
-_func=$(echo "$_complete_stmt" | grep -o -e '-F \w\+' | cut -d ' ' -f 2)
-declare -f "$_func" > /dev/null || exit 1
+if [[ $_complete_stmt =~ "-C" ]] ; then
+    _func=$(eval getarg "-C" $_complete_stmt)
+else
+    _func=$(eval getarg "-F" $_complete_stmt)
+    declare -f "$_func" > /dev/null || exit 1
+fi
 
 echo "$_complete_stmt"
-COMP_WORDS=({line})
-COMP_LINE={comp_line}
-COMP_POINT=${{#COMP_LINE}}
-COMP_COUNT={end}
-COMP_CWORD={n}
+export COMP_WORDS=({line})
+export COMP_LINE={comp_line}
+export COMP_POINT=${{#COMP_LINE}}
+export COMP_COUNT={end}
+export COMP_CWORD={n}
 $_func {cmd} {prefix} {prev}
 
 # print out completions, right-stripped if they contain no internal spaces

--- a/bash_completion.py
+++ b/bash_completion.py
@@ -240,6 +240,7 @@ then
     _complete_stmt=$(_get_complete_statement)
 fi
 
+# Is -C (subshell) or -F (function) completion used?
 if [[ $_complete_stmt =~ "-C" ]] ; then
     _func=$(eval getarg "-C" $_complete_stmt)
 else

--- a/news/fix_completion_with_subshell.rst
+++ b/news/fix_completion_with_subshell.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix completion which uses a subshell environment
+
+**Security:** None


### PR DESCRIPTION
awscli (Amazon Web Services Cli) uses the following completer
```
$ complete -p aws
complete -C 'aws_completer' aws
```

See:
https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#index-complete

`-C` uses a subshell so `exports` are required. I've also implemented a better argument parser because shell quotes (`'aws_completer'`) had to be parsed correctly.